### PR TITLE
Fixed unexpected logs

### DIFF
--- a/pkg/cloudprovider/huaweicloud/clusters.go
+++ b/pkg/cloudprovider/huaweicloud/clusters.go
@@ -19,8 +19,8 @@ package huaweicloud
 import (
 	"context"
 
-	"github.com/prometheus/common/log"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 // NewCluster creates a new cluster instance.
@@ -37,12 +37,12 @@ var _ cloudprovider.Clusters = &Cluster{}
 
 // ListClusters lists the names of the available clusters.
 func (c *Cluster) ListClusters(ctx context.Context) ([]string, error) {
-	log.Warnf("ListClusters is called but not implemented.")
+	klog.Warningf("ListClusters is called but not implemented.")
 	return nil, nil
 }
 
 // Master gets back the address (either DNS name or IP address) of the master node for the cluster.
 func (c *Cluster) Master(ctx context.Context, clusterName string) (string, error) {
-	log.Warnf("ListClusters is called but not implemented. cluster name: %s", clusterName)
+	klog.Warningf("ListClusters is called but not implemented. cluster name: %s", clusterName)
 	return "", nil
 }

--- a/pkg/cloudprovider/huaweicloud/instances.go
+++ b/pkg/cloudprovider/huaweicloud/instances.go
@@ -39,7 +39,7 @@ var _ cloudprovider.Instances = &Instances{}
 
 // NodeAddresses returns the addresses of the specified instance.
 func (i *Instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
-	klog.Warning("NodeAddresses is called, but this interface haven't been implemented. node: %s", name)
+	klog.Warningf("NodeAddresses is called, but this interface haven't been implemented. node: %s", name)
 	return nil, nil
 }
 
@@ -49,7 +49,7 @@ func (i *Instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v
 // from the node whose nodeaddresses are being queried. i.e. local metadata
 // services cannot be used in this method to obtain nodeaddresses
 func (i *Instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
-	klog.Warning("NodeAddressesByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
+	klog.Warningf("NodeAddressesByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
 	return []v1.NodeAddress{}, cloudprovider.NotImplemented
 }
 
@@ -57,33 +57,33 @@ func (i *Instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 // Note that if the instance does not exist, we must return ("", cloudprovider.InstanceNotFound)
 // cloudprovider.InstanceNotFound should NOT be returned for instances that exist but are stopped/sleeping
 func (i *Instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	klog.Warning("InstanceID is called, but this interface haven't been implemented. node: %s", nodeName)
+	klog.Warningf("InstanceID is called, but this interface haven't been implemented. node: %s", nodeName)
 	return "", nil
 }
 
 // InstanceType returns the type of the specified instance.
 func (i *Instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	klog.Warning("InstanceType is called, but this interface haven't been implemented. node: %s", name)
+	klog.Warningf("InstanceType is called, but this interface haven't been implemented. node: %s", name)
 	return "", nil
 }
 
 // InstanceTypeByProviderID returns the type of the specified instance.
 func (i *Instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
-	klog.Warning("InstanceTypeByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
+	klog.Warningf("InstanceTypeByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
 	return "", cloudprovider.NotImplemented
 }
 
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
 // expected format for the key is standard ssh-keygen format: <protocol> <blob>
 func (i *Instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
-	klog.Warning("AddSSHKeyToAllInstances is called, but this interface haven't been implemented. user: %s", user)
+	klog.Warningf("AddSSHKeyToAllInstances is called, but this interface haven't been implemented. user: %s", user)
 	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns the name of the node we are currently running on
 // On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
-	klog.Warning("CurrentNodeName is called, but this interface haven't been implemented. hostname: %s", hostname)
+	klog.Warningf("CurrentNodeName is called, but this interface haven't been implemented. hostname: %s", hostname)
 	return types.NodeName(hostname), nil
 }
 
@@ -91,12 +91,12 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 // This method should still return true for instances that exist but are stopped/sleeping.
 func (i *Instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
-	klog.Warning("InstanceExistsByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
+	klog.Warningf("InstanceExistsByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
 	return false, cloudprovider.NotImplemented
 }
 
 // InstanceShutdownByProviderID returns true if the instance is shutdown in cloudprovider
 func (i *Instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
-	klog.Warning("InstanceShutdownByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
+	klog.Warningf("InstanceShutdownByProviderID is called, but this interface haven't been implemented. providerID: %s", providerID)
 	return false, cloudprovider.NotImplemented
 }

--- a/pkg/cloudprovider/huaweicloud/routes.go
+++ b/pkg/cloudprovider/huaweicloud/routes.go
@@ -19,8 +19,8 @@ package huaweicloud
 import (
 	"context"
 
-	"github.com/prometheus/common/log"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 // NewRoutes creates a new route handler.
@@ -37,7 +37,7 @@ var _ cloudprovider.Routes = &Routes{}
 
 // ListRoutes lists all managed routes that belong to the specified clusterName
 func (r *Routes) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
-	log.Warnf("ListRoutes is called but not implemented. clusterName: %s", clusterName)
+	klog.Warningf("ListRoutes is called but not implemented. clusterName: %s", clusterName)
 
 	return nil, nil
 }
@@ -46,7 +46,7 @@ func (r *Routes) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpr
 // route.Name will be ignored, although the cloud-provider may use nameHint
 // to create a more user-meaningful name.
 func (r *Routes) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
-	log.Warnf("CreateRoute is called but not implemented. clusterName: %s, nameHint: %s", clusterName, nameHint)
+	klog.Warningf("CreateRoute is called but not implemented. clusterName: %s, nameHint: %s", clusterName, nameHint)
 
 	return nil
 }
@@ -54,7 +54,7 @@ func (r *Routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 // DeleteRoute deletes the specified managed route
 // Route should be as returned by ListRoutes
 func (r *Routes) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
-	log.Warnf("ListRoutes is called but not implemented. clusterName: %s", clusterName)
+	klog.Warningf("ListRoutes is called but not implemented. clusterName: %s", clusterName)
 
 	return nil
 }

--- a/pkg/cloudprovider/huaweicloud/zone.go
+++ b/pkg/cloudprovider/huaweicloud/zone.go
@@ -19,9 +19,9 @@ package huaweicloud
 import (
 	"context"
 
-	"github.com/prometheus/common/log"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 // NewZone creates a zone handler.
@@ -41,7 +41,7 @@ var _ cloudprovider.Zones = &Zone{}
 // For the case of external cloud providers, use GetZoneByProviderID or GetZoneByNodeName since GetZone
 // can no longer be called from the kubelets.
 func (z *Zone) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
-	log.Warnf("GetZone is called but not implemented.")
+	klog.Warningf("GetZone is called but not implemented.")
 
 	return cloudprovider.Zone{}, nil
 }
@@ -50,7 +50,7 @@ func (z *Zone) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // This method is particularly used in the context of external cloud providers where node initialization must be done
 // outside the kubelets.
 func (z *Zone) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
-	log.Warnf("GetZoneByProviderID is called but not implemented.")
+	klog.Warningf("GetZoneByProviderID is called but not implemented.")
 
 	return cloudprovider.Zone{}, nil
 }
@@ -59,7 +59,7 @@ func (z *Zone) GetZoneByProviderID(ctx context.Context, providerID string) (clou
 // This method is particularly used in the context of external cloud providers where node initialization must be done
 // outside the kubelets.
 func (z *Zone) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	log.Warnf("GetZoneByNodeName is called but not implemented.")
+	klog.Warningf("GetZoneByNodeName is called but not implemented.")
 
 	return cloudprovider.Zone{}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixed unexpected logs like 
```
W0108 14:41:34.269768   25567 instances.go:94] InstanceExistsByProviderID is called, but this interface haven't been implemented. providerID: %secs-d8b6
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
