### PR TITLE
Update elb and nat for supporting same secret parsing

### DIFF
--- a/examples/loadbalancers/service_enhanced.yaml
+++ b/examples/loadbalancers/service_enhanced.yaml
@@ -11,7 +11,7 @@ metadata:
   name: nginx
 spec:
   loadBalancerIP: 119.8.41.11
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   ports:
     - name: service0
       port: 80


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The `basic load balancer` and `nat` support both `Temporary Security Credentials` and `Permanent Security Credentials`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
