### PR TITLE
Decode all Secret.Data fields by default

### DIFF
--- a/pkg/cloudprovider/huaweicloud/alb.go
+++ b/pkg/cloudprovider/huaweicloud/alb.go
@@ -517,6 +517,11 @@ func (alb *ALBCloud) getSecret(namespace, secretName string) (*Secret, error) {
 		return nil, err
 	}
 
+	if err := secret.DecodeBase64(); err != nil {
+		klog.Errorf("Decode secret failed with error: %v", err)
+		return nil, err
+	}
+
 	return &secret, nil
 }
 

--- a/pkg/cloudprovider/huaweicloud/elb.go
+++ b/pkg/cloudprovider/huaweicloud/elb.go
@@ -78,6 +78,11 @@ func (elb *ELBCloud) getSecret(namespace, secretName string) (*Secret, error) {
 		return nil, err
 	}
 
+	if err := secret.DecodeBase64(); err != nil {
+		klog.Errorf("Decode secret failed with error: %v", err)
+		return nil, err
+	}
+
 	return &secret, nil
 }
 

--- a/pkg/cloudprovider/huaweicloud/nat.go
+++ b/pkg/cloudprovider/huaweicloud/nat.go
@@ -493,6 +493,11 @@ func (nat *NATCloud) getSecret(namespace, secretName string) (*Secret, error) {
 		return nil, err
 	}
 
+	if err := secret.DecodeBase64(); err != nil {
+		klog.Errorf("Decode secret failed with error: %v", err)
+		return nil, err
+	}
+
 	return &secret, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
Decode(base64) everything gets from `Secret.Data` by default.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
