### PR TITLE
Rename provider name from 'hws' to 'huaweicloud'

### DIFF
--- a/pkg/cloudprovider/huaweicloud/huaweicloud.go
+++ b/pkg/cloudprovider/huaweicloud/huaweicloud.go
@@ -49,7 +49,7 @@ import (
 
 // Cloud provider name: PaaS Web Services.
 const (
-	ProviderName               = "hws"
+	ProviderName               = "huaweicloud"
 	ELBIDAnnotation            = "kubernetes.io/elb.id"
 	ELBClassAnnotation         = "kubernetes.io/elb.class"
 	ELBMarkAnnotation          = "kubernetes.io/elb.mark"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Rename cloud provider name from `hws` to `huaweicloud`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Cloud provider name has been changed from `hws` to `huaweicloud`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
